### PR TITLE
Add bi-weekly meeting notes for 2026-03-23

### DIFF
--- a/biweekly_meetings/2026-03-23.md
+++ b/biweekly_meetings/2026-03-23.md
@@ -1,0 +1,65 @@
+# scikit-learn bi-weekly update — 2026-03-23
+
+(This summary is LLM generated, so there might be slight inaccuracies)
+
+## Current focus areas
+
+### Callback API
+
+The SLEP vote has been called, and maintainers have one month to vote
+([scikit-learn/enhancement_proposals#103](https://github.com/scikit-learn/enhancement_proposals/pull/103)).
+The current highest priority is writing end-user and developer documentation
+([#33423](https://github.com/scikit-learn/scikit-learn/pull/33423)) for adding
+callback support in estimators. Work continues on the scoring monitor callback
+([#33407](https://github.com/scikit-learn/scikit-learn/pull/33407),
+[#33611](https://github.com/scikit-learn/scikit-learn/pull/33611)), focusing on the
+best format and representation for logged scores. A PR to add callback support in
+`BaseSearchCV` is ongoing
+([#33533](https://github.com/scikit-learn/scikit-learn/pull/33533)). Jérémie has
+also been working on a wrapper for the callback context to help developers with
+implementation, testing, and debugging
+([#33591](https://github.com/scikit-learn/scikit-learn/pull/33591)). Once the
+scoring callback, progress callback, GridSearchCV, and LogisticRegression all have
+callback support, the team will have the minimal building blocks needed for
+user-facing examples and release highlights.
+
+### HTML representation and displays
+
+- **Output features display**
+  ([#31937](https://github.com/scikit-learn/scikit-learn/pull/31937)): Dea
+  implemented all requested changes for displaying the number and names of output
+  features; waiting for review.
+- **ColumnTransformer HTML display**
+  ([#33531](https://github.com/scikit-learn/scikit-learn/pull/33531)): a test was
+  added, but a suggested code change caused a regression. Waiting to be merged.
+- **Fitted attribute rounding bug**
+  ([#33615](https://github.com/scikit-learn/scikit-learn/pull/33615)): very small
+  positive numbers are incorrectly rounded to zero in the HTML display. A fix
+  using scientific notation is in progress.
+- **Decision boundary display**
+  ([#33419](https://github.com/scikit-learn/scikit-learn/pull/33419)): Anne is
+  reviewing examples that use `DecisionBoundaryDisplay`, focusing on color handling
+  and migrating examples to use `from_estimator`. Reviews are welcome.
+- **Metrics at thresholds**: the plan is to create a display from the implemented
+  `metric_at_thresholds` function
+  ([#32732](https://github.com/scikit-learn/scikit-learn/pull/32732)).
+
+### Performance and scaling
+
+Antoine is continuing work on the hist gradient boosting threading heuristic
+([#30662](https://github.com/scikit-learn/scikit-learn/issues/30662),
+[#32955](https://github.com/scikit-learn/scikit-learn/pull/32955)). Analysis of the
+`predict` method suggests a simple heuristic is possible, as speed is only
+sensitive to the number of samples. For the more complex `fit` method, the proposed
+solution is a utility that warns the user and suggests running a benchmark to
+determine if multi-threading is beneficial.
+
+### CI and contributor tooling
+
+- **Issue warnings**
+  ([#33521](https://github.com/scikit-learn/scikit-learn/pull/33521)): Anne added a
+  GitHub Action that warns contributors on new issues with a "needs" label, to
+  help prevent unapproved contributions.
+- **CI job restrictions**: a PR was opened to restrict CI test jobs to run only on
+  the main repository, preventing unnecessary failure emails from forks.
+


### PR DESCRIPTION
## Summary

- Adds the scikit-learn-focused summary of the 2026-03-23 biweekly meeting
- Covers: callback API (SLEP vote), HTML representation/display fixes, HGB threading heuristic, CI/contributor tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)