### PR TITLE
Add biweekly meeting notes for 2026-03-30

### DIFF
--- a/biweekly_meetings/2026-03-30.md
+++ b/biweekly_meetings/2026-03-30.md
@@ -1,0 +1,90 @@
+# scikit-learn bi-weekly update — 2026-03-30
+
+(This summary is LLM generated, so there might be slight inaccuracies)
+
+## Current focus areas
+
+### Decision boundary display and color accessibility
+
+The ongoing refactoring of `DecisionBoundaryDisplay` color handling
+([#33115](https://github.com/scikit-learn/scikit-learn/issues/33115)) continues.
+The current developer version has inconsistent decision boundary colors on the
+website that need to be fixed before the next stable release. A new PR
+([#33709](https://github.com/scikit-learn/scikit-learn/pull/33709)) proposes
+changing the default discrete color map away from `tab10`, whose first colors
+(blue, orange, green) are not colorblind-friendly. The discussion highlighted
+that ensuring consistent colors between `DecisionBoundaryDisplay` and
+Matplotlib's default scatter plot is currently too cumbersome for users. Input
+from accessibility testers is being sought. The documentation fixes for examples
+using `DecisionBoundaryDisplay` are tracked in
+[#33557](https://github.com/scikit-learn/scikit-learn/issues/33557) — reviewers
+should check whether an example actually shows visual inconsistency before
+opening a fix PR.
+
+### Threading performance for tree-based models
+
+Investigation into the OpenMP threading slowdown
+([#30662](https://github.com/scikit-learn/scikit-learn/issues/30662)) revealed
+that the optimal thread count depends heavily on data shape and platform.
+Threading is especially detrimental on macOS with small datasets, likely due to
+heterogeneous CPU architectures (performance and efficiency cores) and LLVM
+OpenMP behavior. The investigation plan includes: crafting a minimal C/OpenMP
+reproducer for reporting to LLVM developers, testing with GCC inside Docker on
+macOS, and experimenting with dynamic OpenMP scheduling instead of static.
+Input on these approaches is welcome.
+
+### HTML representation and displays
+
+- **Vertical layout**
+  ([#33647](https://github.com/scikit-learn/scikit-learn/pull/33647)): Dea
+  continues experimenting with restructuring the HTML display to be more
+  vertical, which would reduce horizontal scrolling for wide pipelines.
+- **Nested meta-estimator display**
+  ([#33295](https://github.com/scikit-learn/scikit-learn/issues/33295),
+  [#32146](https://github.com/scikit-learn/scikit-learn/issues/32146)): fixing
+  the dotted-squares visualization for meta-estimators containing other
+  meta-estimators is still a work in progress.
+- **ColumnTransformer bug fix**
+  ([#33531](https://github.com/scikit-learn/scikit-learn/pull/33531)): a fix for
+  incorrect fitted attributes in the ColumnTransformer HTML display has been
+  merged and will be included in the next release.
+- **Estimator diagrams**
+  ([#30740](https://github.com/scikit-learn/scikit-learn/pull/30740)): the PR
+  adding documentation illustrations for Pipeline, ColumnTransformer, and
+  FeatureUnion has been given the green light for review. Reviews are welcome.
+
+### Array API
+
+- **Namespace conversion utility**
+  ([#33076](https://github.com/scikit-learn/scikit-learn/pull/33076)): a utility
+  for moving estimators between array namespaces (e.g., GPU to CPU) has been
+  merged, enabling prediction and unpickling on machines without the original
+  hardware.
+- **JAX support**
+  ([#29647](https://github.com/scikit-learn/scikit-learn/pull/29647)): the PR was
+  deprioritized, but test infrastructure refactoring was extracted and merged
+  separately.
+- **Score function usability**: the `score` method has a usability problem with
+  the Array API — an issue will be opened proposing automatic conversion to
+  NumPy for scoring.
+
+### Callbacks and metadata routing
+
+- **Manager instantiation fix**
+  ([#33649](https://github.com/scikit-learn/scikit-learn/pull/33649)): a bug
+  where `ProgressBar` callback failed when instantiated outside
+  `if __name__ == "__main__"` has been fixed by using loky context instead of
+  default multiprocessing.
+- **CallbackContext cleanup**
+  ([#33664](https://github.com/scikit-learn/scikit-learn/pull/33664)): the
+  estimator attribute was removed from `CallbackContext` to avoid pickling
+  issues across processes.
+
+### Website sustainability
+
+A draft PR
+([#33704](https://github.com/scikit-learn/scikit-learn/pull/33704)) proposes
+updating the scikit-learn.org website to more prominently advertise companies
+that support scikit-learn development, improving long-term sustainability.
+Reviews and input are welcome.
+


### PR DESCRIPTION
## Summary

- Adds scikit-learn biweekly meeting summary for March 30, 2026
- Covers: decision boundary color accessibility, threading performance, HTML display improvements, Array API, callbacks, website sustainability, and score API

🤖 Generated with [Claude Code](https://claude.com/claude-code)