### PR TITLE
Add scikit-learn bi-weekly update for 2026-04-27

### DIFF
--- a/biweekly_meetings/2026-04-27.md
+++ b/biweekly_meetings/2026-04-27.md
@@ -1,0 +1,119 @@
+# scikit-learn bi-weekly update — 2026-04-27
+
+(This summary is LLM generated, so there might be slight inaccuracies)
+
+## Current focus areas
+
+### Callbacks API
+
+The callback feature branch keeps progressing toward a minimal-but-complete
+set landing in 1.9. Several pieces merged in the last two weeks:
+
+- **ScoringMonitor callback** ([#33739](https://github.com/scikit-learn/scikit-learn/pull/33739)):
+  merged, along with the associated user documentation
+  ([#33812](https://github.com/scikit-learn/scikit-learn/pull/33812)).
+- **StandardScaler callback support** ([#33796](https://github.com/scikit-learn/scikit-learn/pull/33796)):
+  merged.
+- **Context-manager `propagate_callback_context`** ([#33799](https://github.com/scikit-learn/scikit-learn/pull/33799)):
+  merged.
+
+In progress and looking for reviewers:
+
+- **Main callbacks API PR** ([#33322](https://github.com/scikit-learn/scikit-learn/pull/33322))
+  has been moved to "ready for review" to attract reviewers ahead of the
+  feature-branch merge into `main`.
+- **Pipeline support** ([#33787](https://github.com/scikit-learn/scikit-learn/pull/33787)),
+  **`LogisticRegression` (lbfgs) support** ([#33847](https://github.com/scikit-learn/scikit-learn/pull/33847)),
+  and **`BaseSearchCV` support** ([#33533](https://github.com/scikit-learn/scikit-learn/pull/33533)):
+  all open and close to ready.
+- **Gallery example for custom estimators**
+  ([#33771](https://github.com/scikit-learn/scikit-learn/pull/33771)): in review.
+
+The plan is to merge a minimal working subset of these for the 1.9 release.
+Reviews on [#33322](https://github.com/scikit-learn/scikit-learn/pull/33322)
+and the per-estimator integrations are especially welcome.
+
+### `DecisionBoundaryDisplay` examples cleanup
+
+Following the recent default-colors update, Anne Beyer is working through the
+gallery to bring all `DecisionBoundaryDisplay` examples in line with the new
+defaults. Several small per-example PRs landed since the last update
+([#33849](https://github.com/scikit-learn/scikit-learn/pull/33849),
+[#33817](https://github.com/scikit-learn/scikit-learn/pull/33817),
+[#33808](https://github.com/scikit-learn/scikit-learn/pull/33808)), with more
+open:
+
+- **Examples update PR** ([#33805](https://github.com/scikit-learn/scikit-learn/pull/33805))
+  and **NCA example colors** ([#33869](https://github.com/scikit-learn/scikit-learn/pull/33869)):
+  open and ready for review — Antoine Baker volunteered to review one of them.
+- **Tracking issue** ([#33557](https://github.com/scikit-learn/scikit-learn/issues/33557)):
+  list of remaining examples that still need updating; new contributions
+  picking individual examples off this list are welcome.
+
+### HTML representation and displays
+
+Dea María Léon merged a batch of bug fixes for the estimator HTML
+representation:
+
+- [#33779](https://github.com/scikit-learn/scikit-learn/pull/33779) — display
+  output features in `CountVectorizer`.
+- [#33821](https://github.com/scikit-learn/scikit-learn/pull/33821) — add
+  scroll for long HTML displays.
+- [#33831](https://github.com/scikit-learn/scikit-learn/pull/33831) — fix
+  documentation links for parameter names with special characters.
+
+In progress:
+
+- **`TransformerTargetRegressor` HTML display fix**
+  ([#33850](https://github.com/scikit-learn/scikit-learn/pull/33850)): open
+  draft.
+- **Vertical HTML display structure** ([#33678](https://github.com/scikit-learn/scikit-learn/pull/33678)):
+  the team is asking for **user-perspective feedback** rather than code review
+  on whether the proposed vertical layout is the desired direction. If you
+  rely on the estimator HTML repr, please try the PR and share your reaction.
+
+### Calibration: bin strategy and ECE
+
+The team converged this week on a direction for the calibration metrics work:
+
+- Add an explicit option for the **number of bins** in `calibration_curve` and
+  `CalibrationDisplay`. Consensus is to follow the **Rice rule** (square-root
+  of the sample size) for the default, mirroring the NumPy histogram API.
+- Switch the **default binning strategy to quantile (equal-mass) bins**
+  instead of equal-width, which is unstable and noisy under the current
+  default. This is supported by an existing literature consensus, including
+  the Roloff et al. paper that Gaël will share for reference.
+- **Expected Calibration Error (ECE)** is the next metric to land on top of
+  the bin-strategy work.
+- **Debiasing for ECE and related metrics** is acknowledged as a real concern
+  in recent literature; the team wants to clarify the state of the art before
+  implementing, with uncertainty estimation (likely bootstrap-based) as a
+  follow-up.
+
+The plan is to keep the discussions focused — bin strategy, bin count, and
+ECE first — rather than bundle every calibration metric into one design.
+Antoine Baker is leading this with input from Olivier Grisel, Gaël Varoquaux,
+and Shruti Nath.
+
+### Sample-weight statistical correctness and SAGA
+
+Shruti Nath reports the **sample-weight statistical-correctness PR**
+([#31675](https://github.com/scikit-learn/scikit-learn/pull/31675), fixing
+sample weight handling in SAG/SAGA) is ready to merge. The related SAGA draft
+is unblocked; remaining work is making sure all tests pass for the Cython
+version.
+
+### Array API and the Intel partnership
+
+- A pull request enabling Intel GPU libraries on the Array API is in progress.
+- **`dpnp` array API namespace** ([#32460](https://github.com/scikit-learn/scikit-learn/pull/32460)):
+  open, registers `dpnp` as an additional namespace to test against.
+
+### Other items in progress
+
+- **Institutional / financial supporters revamp**
+  ([#33704](https://github.com/scikit-learn/scikit-learn/pull/33704)):
+  Olivier's PR is close. Remaining items are some Inkscape/SVG cleanup and a
+  design question on how to display institutional support relative to other
+  groups — input from Gaël is being sought asynchronously.
+


### PR DESCRIPTION
Bi-weekly summary covering the 2026-04-27 meeting.

Note: this summary is LLM-generated from the meeting notes, with PR/issue links resolved against the scikit-learn repo. Reviewed by @adrinjalali before opening.