### PR TITLE
Add biweekly meeting notes for 2026-05-18

### DIFF
--- a/biweekly_meetings/2026-05-18.md
+++ b/biweekly_meetings/2026-05-18.md
@@ -1,0 +1,103 @@
+# scikit-learn bi-weekly update — 2026-05-18
+
+(This summary is LLM generated, so there might be slight inaccuracies)
+
+## Current focus areas
+
+### Callbacks API
+
+The callbacks feature continues moving toward the 1.9 release. The main
+callbacks PR ([#33322](https://github.com/scikit-learn/scikit-learn/pull/33322))
+remains open and the team is working through the remaining pieces:
+
+- **Context-manager semantics for `propagate_callback_context`**
+  ([#34044](https://github.com/scikit-learn/scikit-learn/pull/34044)): open.
+  The team discussed adding a runtime warning for non-context-manager usage
+  but decided against it due to added complexity. Instead, they will open an
+  issue to track the creation of common tests that verify proper hook
+  invocation. Reviews on the PR are welcome.
+- **Free-threaded Python and parallel subcontext fix**
+  ([#34027](https://github.com/scikit-learn/scikit-learn/pull/34027)): open,
+  addresses resource exhaustion and thread safety issues; relevant tests will
+  be skipped on Pyodide.
+- **Skip callback tests on Pyodide**
+  ([#34013](https://github.com/scikit-learn/scikit-learn/pull/34013)): open.
+
+### Release 1.9
+
+Seven items remain open in the
+[1.9 milestone](https://github.com/scikit-learn/scikit-learn/milestone/69).
+Notable pending merge:
+
+- **`LogisticRegressionCV.score` and `_BaseScorer` metadata routing fix**
+  ([#30859](https://github.com/scikit-learn/scikit-learn/pull/30859)): the
+  team agreed this should be merged promptly.
+- **Quantile Transformer sample weight**
+  ([#32761](https://github.com/scikit-learn/scikit-learn/pull/32761)): the
+  current bin-counting implementation was flagged as problematic because it
+  relies too heavily on the scale of the weights, which can lead to
+  single-bin outputs. Needs rework before merge.
+
+The scaler comparison gallery example was moved to a future milestone due to
+lack of review bandwidth this cycle.
+
+### Calibration curves
+
+Two open PRs are moving the calibration tooling forward:
+
+- **Cube-root bin count option**
+  ([#33856](https://github.com/scikit-learn/scikit-learn/pull/33856)): adds a
+  `'cube_root'` option for the `n_bins` parameter in `calibration_curve` and
+  `CalibrationDisplay`. Reviews welcome.
+- **Default strategy to `'quantile'`**
+  ([#33908](https://github.com/scikit-learn/scikit-learn/pull/33908)): changes
+  the default binning strategy from equal-width to equal-mass bins, which is
+  more robust. Reviews welcome.
+
+The team also discussed the limitations of isotonic regression as a
+calibration method, noting that it can be blind to misspecified models with
+non-monotonic true calibration curves. A notebook will be developed to
+document and demonstrate this behavior alongside the various binning
+approaches.
+
+### Narwhals and Pyodide compatibility
+
+The latest version of the Narwhals library introduces a dependency conflict
+that prevents scikit-learn from being installed on certain Pyodide deployments.
+The team agreed to investigate whether depending on Narwhals version 1 is
+feasible as a workaround. An issue will be opened to track this.
+
+### `DecisionBoundaryDisplay` binary/multiclass alignment
+
+Anne Beyer reported that color inconsistencies in the existing examples are
+now resolved. A silent change in the internal handling of the boundary display
+for binary versus multiclass cases was accepted as a bug fix in the changelog.
+The next planned step is to deprecate the multiclass-specific parameters in
+order to align the binary and multiclass code paths.
+
+### SAGA sample weight correctness
+
+Antoine Baker's PR adapting step size and SAG updates for sample weights
+([#31837](https://github.com/scikit-learn/scikit-learn/pull/31837)) is close
+to ready. The remaining step before final review is removing the draft status.
+
+### Other items in progress
+
+- **Metadata routing deprecation**: deprioritized for the next few months to
+  keep focus on the callbacks work and the 1.9 release.
+- **RidgeClassifier accuracy with Series input**: a bug was identified where
+  the accuracy metric behaves incorrectly when the target is a pandas Series
+  rather than an array. This is part of a broader effort to align estimators
+  with the policy for `X` and `sample_weight` inputs.
+- **Multi-threading in Logistic Regression**: benchmarks show performance
+  gains from multi-threading are minimal following the removal of `n_jobs`,
+  and may even degrade performance for small sample sizes; no action planned
+  for now.
+- **Thread usage in tree-based estimators**: exploring strategies to avoid
+  spinning up threads on small problems, to reduce overhead on devices like
+  Macs and recent Intel CPUs.
+- **Intel CI security**
+  ([scikit-learn-intel-workflow](https://github.com/probabl-ai/scikit-learn-intel-workflow/)):
+  Arthur Lacote is implementing dependency locking via Pixi to harden the CI
+  machine; date-based locking is currently blocked by infrastructure issues
+  with the custom PyTorch XPU index.


### PR DESCRIPTION
Scikit-learn focused summary of the May 18, 2026 Probabl bi-weekly meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)